### PR TITLE
QR Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Build for Production
 npm run build
 ```
 
+## Rendered Display Examples
+### Silverscreen
+http://localhost:8080/?variant=2&list=bluecinema:weekend&cinema=Capitol&place=Lucerne&room=42
+
+### Lobby Vertical
+http://localhost:8080/?variant=3&list=bluecinema:weekend&cinema=Capitol&place=Lucerne&room=42
+
+### Lobby Horizontal
+http://localhost:8080/?variant=4&list=bluecinema:weekend&cinema=Capitol&place=Lucerne&room=42
+
+
 ## Changelog
 ```
 0.0.1 - Initial setup
@@ -27,4 +38,5 @@ npm run build
 0.0.8 - Added scale transition to QR Code in variant 2
 0.0.9 - Standard is now for Lobby Landscape and Portrait, Variant 2 is now for Silverscreen. Silverscreen animation updated. Startup fixed.
 0.1.0 - New Setup for Production
+0.1.1 – Updated QR animation (removed glow, larger target size in variant 2)
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blue-news-displays",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Show Blue News on Cinema Displays",
   "private": true,
   "scripts": {

--- a/src/scss/atoms/qr-code.scss
+++ b/src/scss/atoms/qr-code.scss
@@ -33,14 +33,8 @@
     }
 }
 
-@keyframes glow {
-    0%      {box-shadow: 0 0 transparent; transform: scale(1);}
-    50%   {box-shadow: 0 0 $space-vw $space-vw / 4 $color-blue-2; transform: scale(1.05);}
-    100%    {box-shadow: 0 0 transparent; transform: scale(1);}
-}
-
-@keyframes glow-in-portrait {
-    0%      {box-shadow: 0 0 transparent; transform: scale(1);}
-    50%   {box-shadow: 0 0 2 * $space-vw $space-vw / 2 $color-blue-2; transform: scale(1.05);}
-    100%    {box-shadow: 0 0 transparent; transform: scale(1);}
+@keyframes bump {
+    0%      {transform: scale(1);}
+    50%     {transform: scale(1.05);}
+    100%    {transform: scale(1);}
 }

--- a/src/scss/molecules/slide.scss
+++ b/src/scss/molecules/slide.scss
@@ -53,6 +53,7 @@
 
     &__code {
         position: absolute;
+        z-index: 1;
         right: 0;
         bottom: calc((100vh - 15 * #{$space-vw}) / 2);
         margin-bottom: 0;
@@ -132,13 +133,9 @@
 
         .a-qr-code {
             &__code {
-                animation-name: glow;
+                animation-name: bump;
                 animation-duration: 1s;
                 animation-delay: 6.5s;
-
-                @include in-portrait {
-                    animation-name: glow-in-portrait;
-                }
             }
         }
 

--- a/src/scss/templates/display-variant-2.scss
+++ b/src/scss/templates/display-variant-2.scss
@@ -2,7 +2,7 @@
 .t-display--variant-2 {
     .m-slide {
         &__info {
-            right: $space-vw;
+            right: 0;
         }
 
         &.is-current,
@@ -22,7 +22,7 @@
     }
 
     .a-qr-code {
-        width: 14.5 * $space-vw;
+        width: 17 * $space-vw;
         transform: translateY(50%) scale(.5);
 
         &::after {


### PR DESCRIPTION
- Removed blue glow in bump animation
- Increased QR's target size in variant 2
- Bumped version
- Updated changelog
- Added example URLs to readme

### New target QR Size in Variant 2
<img width="1023" alt="Bildschirmfoto 2020-11-25 um 09 27 36" src="https://user-images.githubusercontent.com/36032868/100201610-8d2d6500-2f00-11eb-8f32-438567f768c9.png">
